### PR TITLE
Jt/py3 chat parsing

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/pympi/Elan.py
+++ b/pympi/Elan.py
@@ -1406,7 +1406,7 @@ class Eaf:
         return tgout
 
 
-def eaf_from_chat(file_path, codec='ascii', extension='wav'):
+def eaf_from_chat(file_path, codec=None, extension='wav'):
     """Reads a .cha file and converts it to an elan object. The functions tries
     to mimic the CHAT2ELAN program that comes with the CLAN package as close as
     possible. This function however converts to the latest ELAN file format
@@ -1430,9 +1430,15 @@ def eaf_from_chat(file_path, codec='ascii', extension='wav'):
         'child', constraints='Symbolic_Association', timealignable=False)
     participantsdb = {}
     last_annotation = None
-    with open(file_path, 'r') as chatin:
+    # attempt to resolve the file codec
+    if codec is None:
+        codec = 'ascii'
+        with open(file_path, 'r', encoding=codec) as chatin:
+            if '@UTF8' == chatin.readline():
+                codec = 'utf8'
+    with open(file_path, 'r', encoding=codec) as chatin:
         while True:
-            line = chatin.readline().strip().decode(codec)
+            line = chatin.readline().strip()
             if line == '@UTF8':  # Codec marker
                 codec = 'utf8'
                 continue

--- a/pympi/Elan.py
+++ b/pympi/Elan.py
@@ -1456,10 +1456,12 @@ def eaf_from_chat(file_path, codec=None, extension='wav'):
             continue
         elif line == '@Begin':
             continue
+        elif line == '@New Episode':
+            continue
         elif line == '@End':  # End of file marker
             end_flag = True
             continue
-        elif line.startswith('@') and line != '@Begin':  # Header marker
+        elif line.startswith('@'):  # Header marker
             key, value = line.split(':\t')
             eafob.add_property('{}:\t'.format(key), value)
             if key == '@Languages':

--- a/pympi/Elan.py
+++ b/pympi/Elan.py
@@ -490,7 +490,7 @@ class Eaf:
         for t in eaf_out.get_tier_names():
             for ab, ae, value in eaf_out.get_annotation_data_for_tier(t):
                 if ab > end or ae < start:
-                    eaf_out.remove_annotation(t, (ae - ab) // 2, False)
+                    eaf_out.remove_annotation(t, (ae + ab) // 2, False)
         eaf_out.clean_time_slots()
         return eaf_out
 

--- a/pympi/Elan.py
+++ b/pympi/Elan.py
@@ -1432,7 +1432,7 @@ def eaf_from_chat(file_path, codec=None, extension='wav'):
     last_annotation = None
     # attempt to resolve the file codec
     if codec is None:
-        codec = 'ascii'
+        codec = 'latin-1'
         with open(file_path, 'r', encoding=codec) as chatin:
             if '@UTF8' == chatin.readline():
                 codec = 'utf8'
@@ -1453,13 +1453,13 @@ def eaf_from_chat(file_path, codec=None, extension='wav'):
                 elif key == '@Participants':
                     for participant in value.split(','):
                         splits = participant.strip().split(' ')
-                        splits = map(lambda x: x.replace('_', ' '), splits)
+                        splits = [part.replace('_', ' ') for part in splits]
                         if len(splits) == 2:
                             participantsdb[splits[0]] = (None, splits[1])
                         elif len(splits) == 3:
                             participantsdb[splits[0]] = (splits[1], splits[2])
                 elif key == '@ID':
-                    ids = map(lambda x: x.replace('_', ''), value.split('|'))
+                    ids = [part.replace('_', '') for part in value.split('|')]
                     eafob.add_tier(ids[2], part=participantsdb[ids[2]][0],
                                    language=ids[0])
                 elif key == '@Media':
@@ -1471,12 +1471,12 @@ def eaf_from_chat(file_path, codec=None, extension='wav'):
                         eafob.tiers[tier][2]['ANNOTATOR'] = value
             elif line.startswith('*'):  # Main tier marker
                 while len(line.split('\x15')) != 3:
-                    line += chatin.readline().decode(codec).strip()
+                    line += chatin.readline().strip()
                 for participant in participantsdb.keys():
                     if line.startswith('*{}:'.format(participant)):
                         splits = ''.join(line.split(':')[1:]).strip()
                         utt, time, _ = splits.split('\x15')
-                        time = map(int, time.split('_'))
+                        time = [int(part) for part in time.split('_')]
                         last_annotation = (participant, time[0], time[1], utt)
                         eafob.add_annotation(*last_annotation)
             elif line.startswith('%'):  # Dependant tier marker

--- a/test/test_elan.py
+++ b/test/test_elan.py
@@ -336,7 +336,7 @@ class Elan(unittest.TestCase):
             [(1000, 2000, 'a2'), (2000, 3000, 'a3')])
         e1 = self.eaf.extract(1000, 2000)
         self.assertEqual(sorted(e1.get_annotation_data_for_tier('tier1')),
-            [(1000, 2000, 'a2'), (2000, 3000, 'a3')])
+            [(0, 1000, 'a1'), (1000, 2000, 'a2'), (2000, 3000, 'a3')])
         e1 = self.eaf.extract(4001, 30000)
         self.assertEqual(sorted(e1.get_annotation_data_for_tier('tier1')), [])
 


### PR DESCRIPTION
### Purpose of this PR
This PR updates the `eaf_from_chat` function so that it
- opens the `.cha` file with the appropriate codec (as opposed to string decoding line by line)
- handles missing annotation time stamps (occurs in some `.cha` files in phonbank)
- handles continuation lines, e.g., *CHI transcripts which are broken across multiple lines

Other changes to pass tests
- The extract function probably should have been using the mid point of an annotation start & end
- The test for the extract function was not inclusive of annotation start time (I believe the function is intended to be inclusive).
- Github's actions/setup-python@v2 no longer supports python 3.5 or3.6

### How it works
- If no codec is supplied, we try to check whether there is a `@UTF8` directive. Finally, we open the file in whatever codec the function has resolved.
- We read all the lines into memory and concatenate continuation-lines
- If a main transcript line does not include a timestamp, we use the previous annotation's timestamp (because it is proximal) and if there is no previous annotation, we use times: (0,1)

### Testing
I tested this new script with all `.cha` files from the Manchester & Providence corpora.

```
# 36906ceeffe486c502d22f9258ef12efd00c5d99
Handle @New Episode
parsed_files: 379
parse_errors: 0
parse_timeouts: 0
n_annotations: 1605747

# 8b7b4d17ab14a2e7a098863398bbd756d50afa52
file continuation handling
parsed_files: 377
parse_errors: 2
parse_timeouts: 0
n_annotations: 1597993

# 77c4d936d21fdbb38780074ae255f12a3175d48b
handle missing timestamps
parsed_files: 270
parse_errors: 109
parse_timeouts: 0
n_annotations: 1086819

# 720aec6b8328cd9e2e721ee53c70542522dcf3c6
file codec w/python3 strings
parsed_files: 67
parse_errors: 71
parse_timeouts: 241
n_annotations: 219883

# 399581baa5828a441eb682e1f8c96827606416b9
previous HEAD
parsed_files: 0
parse_errors: 379
parse_timeouts: 0
n_annotations: 0
```

Test script:
```python
import glob
import multiprocessing

import pympi

corpus_root = "./chat"

def main():
    parsed_files = 0
    parse_errors = 0
    parse_timeouts = 0
    n_annotations = 0

    q = multiprocessing.Queue()

    for file_path in glob.glob('{}/*.cha'.format(corpus_root)):
        print(file_path)
        p = multiprocessing.Process(target=parse, args=(q, file_path))
        p.start()
        p.join(3)
        if p.is_alive():
            parse_timeouts += 1
            continue
        parsed, annotations = q.get()
        if not parsed:
            parse_errors += 1
            continue
        parsed_files += 1
        n_annotations += annotations
    print(
        "parsed_files:", parsed_files, "parse_errors:", parse_errors,
        "parse_timeouts:", parse_timeouts, "n_annotations:", n_annotations
    )

def parse(q, file_path):
    try:
        eafob = pympi.Elan.eaf_from_chat(file_path)
        q.put((1, len(eafob.annotations)))
    except:
        q.put((0, 0))
    return

if __name__ == "__main__":
    main()
```

There appear to be some tests which do not pass, but this does not seem to be the result of changes made in this commit.