### PR TITLE
TextGrid: multi-line parsing, escaped quote parsing

### DIFF
--- a/pympi/Praat.py
+++ b/pympi/Praat.py
@@ -109,7 +109,7 @@ class TextGrid:
 
             regfloat = re.compile(r'([\d.]+)\s*$', flags = re.UNICODE)
             regint = re.compile(r'([\d]+)\s*$', flags = re.UNICODE)
-            regstr = re.compile(r'"(.*)"\s*$', flags = re.UNICODE | re.DOTALL)
+            regstr = re.compile(r'^[^"]*"((?:""|[^"])*)"\s*$', flags = re.UNICODE | re.DOTALL)
 
             def parse_float():
 
@@ -126,7 +126,7 @@ class TextGrid:
                 while True:
 
                     try:
-                        return regstr.search(line_str).group(1)
+                        return regstr.search(line_str).group(1).replace('""', '"')
                     except AttributeError:
                         pass
 

--- a/pympi/Praat.py
+++ b/pympi/Praat.py
@@ -138,7 +138,7 @@ class TextGrid:
             self.xmax = parse_float()
             # Skip <exists>
             line = next_line()
-            short = line.strip() == b'<exists>'
+            short = line.strip() == '<exists>'
             self.tier_num = parse_int()
             not short and next_line()
             for i in range(self.tier_num):


### PR DESCRIPTION
These are fixes for some problem encountered while parsing some of our TextGrids:

1. Sometimes broken line-by-line decoding of n-byte encodings like UTF-16.
2. Inability to parse texts with newlines in them.
3. Inner text quotes escaped by doubling remaining doubled.

PR a) reworks line-by-line decoding of text format TextGrids to whole file decoding, b) enables parsing of multiline texts containing arbitrary number of newlines by repeatedly looking at more and more lines until the whole text is completed, and c) properly turns double-escaped quotes inside each read text back into single quotes after the text is read.