### PR TITLE
Allow ELAN timestamp ids to include letters when saving

### DIFF
--- a/pympi/Elan.py
+++ b/pympi/Elan.py
@@ -1727,7 +1727,10 @@ def to_adocument(eaf_obj, pretty=True):
         etree.SubElement(HEADER, 'PROPERTY', {'NAME': k}).text = str(v)
     # Time order
     TIME_ORDER = etree.SubElement(ADOCUMENT, 'TIME_ORDER')
-    for t in sorted(eaf_obj.timeslots.items(), key=lambda x: int(x[0][2:])):
+    for t in sorted(
+        eaf_obj.timeslots.items(),
+        key=lambda x: (int(re.findall(r"ts(\d+)", x[0])[0]), x[0]),
+    ):
         etree.SubElement(TIME_ORDER, 'TIME_SLOT', rm_none(
             {'TIME_SLOT_ID': t[0], 'TIME_VALUE': t[1]}))
     # Tiers


### PR DESCRIPTION
I encountered an error where an ELAN document cannot be saved because some of the time stamp ids have the format of `ts{number}_{letters}` instead of `ts{number}`.  I don't know ELAN enough to know why this happens but the ELAN validator does not complain about this and the files can be loaded and saved normally in ELAN.

The fix is to use a regular expression to grab the number for primary sorting key and use the string itself for secondary sorting key.

An example eaf file is attached here: https://gist.github.com/taiqihe/8cc3799115d96a133cfc7c17bab7e50c