### PR TITLE
Fix issue #61: allow controlled vocabulary reference in linguistic types

### DIFF
--- a/pympi/Elan.py
+++ b/pympi/Elan.py
@@ -240,13 +240,14 @@ class Eaf:
         """
         self.licenses.append((name, url))
 
-    def add_linguistic_type(self, lingtype, constraints=None,
+def add_linguistic_type(self, lingtype, constraints=None, controlled_vocabulary=None,
                             timealignable=True, graphicreferences=False,
                             extref=None, param_dict=None):
         """Add a linguistic type.
 
         :param str lingtype: Name of the linguistic type.
         :param str constraints: Constraint name.
+        :param str controlled_vocabulary: Controlled vocabulary id.
         :param bool timealignable: Flag for time alignable.
         :param bool graphicreferences: Flag for graphic references.
         :param str extref: External reference.
@@ -268,6 +269,8 @@ class Eaf:
                 'CONSTRAINTS': constraints}
             if extref is not None:
                 self.linguistic_types[lingtype]['EXT_REF'] = extref
+            if controlled_vocabulary is not None:
+                self.linguistic_types[lingtype]['CONTROLLED_VOCABULARY_REF'] = controlled_vocabulary
 
     def add_linked_file(self, file_path, relpath=None, mimetype=None,
                         time_origin=None, ex_from=None):


### PR DESCRIPTION
This PR fixes issue #61.

What was wrong:
- There was no way to reference a controlled vocabulary (CONTROLLED_VOCABULARY_REF)
  when defining a LINGUISTIC_TYPE.

What this PR does:
- Adds an optional controlled_vocabulary argument to Elan.add_linguistic_type()
- When provided, the argument is written as CONTROLLED_VOCABULARY_REF in the ELAN file

API change:
- Elan.add_linguistic_type(..., controlled_vocabulary=None)

Closes #61